### PR TITLE
Read node coord section for explicit instances

### DIFF
--- a/src/Instance.cpp
+++ b/src/Instance.cpp
@@ -53,6 +53,15 @@ Instance::Instance(const char* instanciaPath) {
                 coordOrMatrix[j][i] = coordOrMatrix[i][j];
             }
         }
+
+        fscanf(file, "\n");
+        fscanf(file, "NODE_COORD_SECTION\n");
+        int vertex_index;
+        double x, y;
+        for (int i = 0; i < dimension; ++i) {
+            fscanf(file, "%d %lf %lf", &vertex_index, &x, &y);
+        }
+
     }
 
     fscanf(file, "\n");


### PR DESCRIPTION
Skip coordinates to read demands correctly